### PR TITLE
v1.0.1: patched critical bug in `create_simulation_matrix`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CoinfectionSimulator"
 uuid = "7d77d32e-a319-475a-a7da-1ed1d9bcafc7"
 authors = ["July Pilowsky <japilo@users.noreply.github.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/data_prep.jl
+++ b/src/data_prep.jl
@@ -43,48 +43,48 @@ matrix = create_interaction_matrix(2, "asymmetric", 0.3, cf_ratio=0.8)
 ```
 """
 function create_interaction_matrix(
-	strains::Int,
-	priority_effects::Bool,
-	interaction_strength::Float64;
-	cf_ratio::Float64 = 0.5,
+    strains::Int,
+    priority_effects::Bool,
+    interaction_strength::Float64;
+    cf_ratio::Float64=0.5,
 )
-	strains > 0 || throw(ArgumentError("Number of strains must be positive"))
-	0 ≤ interaction_strength ≤ 1 || throw(ArgumentError("Interaction strength must be between 0 and 1"))
-	0 ≤ cf_ratio ≤ 1 || throw(ArgumentError("Facilitation/competition ratio must be between 0 and 1"))
+    strains > 0 || throw(ArgumentError("Number of strains must be positive"))
+    0 ≤ interaction_strength ≤ 1 || throw(ArgumentError("Interaction strength must be between 0 and 1"))
+    0 ≤ cf_ratio ≤ 1 || throw(ArgumentError("Facilitation/competition ratio must be between 0 and 1"))
 
-	# Initialize matrix with ones on diagonal
-	matrix = Matrix{Float64}(I, strains, strains)
+    # Initialize matrix with ones on diagonal
+    matrix = Matrix{Float64}(I, strains, strains)
 
-	# If interaction strength is 0, return the identity matrix
-	interaction_strength ≈ 0.0 && return matrix
+    # If interaction strength is 0, return matrix of all ones
+    interaction_strength ≈ 0.0 && return Matrix{Float64}(ones(strains, strains))
 
-	# Create off-diagonal indices
-	off_diag_indices = [(i, j) for i in 1:strains for j in 1:strains if i != j]
+    # Create off-diagonal indices
+    off_diag_indices = [(i, j) for i in 1:strains for j in 1:strains if i != j]
 
-	# Sample facilitative indices
-	n_facilitative = round(Int, cf_ratio * length(off_diag_indices))
-	fac_indices = StatsBase.sample(off_diag_indices, n_facilitative, replace = false)
-	comp_indices = setdiff(off_diag_indices, fac_indices)
+    # Sample facilitative indices
+    n_facilitative = round(Int, cf_ratio * length(off_diag_indices))
+    fac_indices = StatsBase.sample(off_diag_indices, n_facilitative, replace=false)
+    comp_indices = setdiff(off_diag_indices, fac_indices)
 
-	# Fill matrix with interaction values
-	for (i, j) in fac_indices
-		matrix[i, j] = rand(Uniform(1.0, 1 + interaction_strength))
-	end
+    # Fill matrix with interaction values
+    for (i, j) in fac_indices
+        matrix[i, j] = rand(Uniform(1.0, 1 + interaction_strength))
+    end
 
-	for (i, j) in comp_indices
-		matrix[i, j] = rand(Uniform(1 - interaction_strength, 1.0))
-	end
+    for (i, j) in comp_indices
+        matrix[i, j] = rand(Uniform(1 - interaction_strength, 1.0))
+    end
 
-	# For symmetric matrices, ensure M[i,j] = M[j,i]
-	if !priority_effects
-		for i in 1:strains
-			for j in (i+1):strains
-				matrix[j, i] = matrix[i, j]
-			end
-		end
-	end
+    # For symmetric matrices, ensure M[i,j] = M[j,i]
+    if !priority_effects
+        for i in 1:strains
+            for j in (i+1):strains
+                matrix[j, i] = matrix[i, j]
+            end
+        end
+    end
 
-	return matrix
+    return matrix
 end
 
 """
@@ -132,23 +132,23 @@ matrices = create_interaction_matrix(df)
 ```
 """
 function create_interaction_matrix(df::DataFrame)
-	# Validate required columns
-	required_columns = [:interaction_strength, :cf_ratio, :priority_effects, :strains]
-	for col in required_columns
-		if !hasproperty(df, col)
-			throw(ArgumentError("DataFrame must contain column: $col"))
-		end
-	end
+    # Validate required columns
+    required_columns = [:interaction_strength, :cf_ratio, :priority_effects, :strains]
+    for col in required_columns
+        if !hasproperty(df, col)
+            throw(ArgumentError("DataFrame must contain column: $col"))
+        end
+    end
 
-	# Create matrices for each row
-	matrices = map(eachrow(df)) do row
-		create_interaction_matrix(
-			row.strains,
-			row.priority_effects,
-			row.interaction_strength;
-			cf_ratio = row.cf_ratio,
-		)
-	end
+    # Create matrices for each row
+    matrices = map(eachrow(df)) do row
+        create_interaction_matrix(
+            row.strains,
+            row.priority_effects,
+            row.interaction_strength;
+            cf_ratio=row.cf_ratio,
+        )
+    end
 
-	return matrices
+    return matrices
 end

--- a/test/test_data_prep.jl
+++ b/test/test_data_prep.jl
@@ -17,9 +17,9 @@ using LinearAlgebra
         @test all(diag(matrix2) .== 1.0)
         @test issymmetric(matrix2)  # Should be symmetric without priority effects
 
-        # Test with zero interaction strength (should be identity matrix)
+        # Test with zero interaction strength (should be all ones)
         matrix3 = create_interaction_matrix(2, true, 0.0)
-        @test matrix3 ≈ Matrix{Float64}(I, 2, 2)
+        @test matrix3 ≈ Matrix{Float64}(ones(2, 2))
 
         # Test with high facilitation ratio
         matrix4 = create_interaction_matrix(5, false, 0.5, cf_ratio=0.9)


### PR DESCRIPTION
All transmission was cut off if the interaction strength in `create_simulation_matrix` was set to zero. I fixed this by making sure that a matrix of all ones (no change to transmission) was returned if `interaction_strength = 0`. 